### PR TITLE
fix: improve error message for insufficient colors

### DIFF
--- a/bumplot/main.py
+++ b/bumplot/main.py
@@ -60,10 +60,11 @@ def bumplot(
     if colors is None:
         colors: list[str] = _get_first_n_colors(n=len(y_columns))
     else:
-        assert len(y_columns) <= len(colors), (
-            f"Not enough colors, expected <={len(y_columns)}, found {len(colors)}"
-        )
-
+        if len(colors) < len(y_columns):
+            raise ValueError(
+                f"The number of colors provided ({len(colors)}) is insufficient. "
+                f"Expected at least {len(y_columns)} colors to match the {len(y_columns)} data series."
+            )
     ranked: IntoDataFrame = _ranked_df(data, x=x, y_columns=y_columns)
     x_values_raw: np.ndarray = np.ravel(ranked.select(x).to_numpy())
 


### PR DESCRIPTION
## Description
This PR fixes the confusing error message when insufficient colors are provided (#5).

## Changes
- Replaced incorrect assert condition with proper validation
- Improved error message to be more informative and user-friendly
- Uses ValueError instead of AssertionError for better practice

## Before
AssertionError: Not enough colors, expected <=4, found 2


## After
ValueError: The number of colors provided (2) is insufficient. Expected at least 4 colors to match the 4 data series.


Closes #5