### PR TITLE
feat: exploring bumplot as plotnine geoms

### DIFF
--- a/bumplot/geoms.py
+++ b/bumplot/geoms.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.patches as patches
+from matplotlib.path import Path
+from matplotlib.collections import PathCollection
+from matplotlib.patches import PathPatch
+from typing import Any
+
+from .main import bumplot
+from .bezier import bezier_curve
+
+try:
+    from plotnine._utils import SIZE_FACTOR, to_rgba
+    from plotnine import geom_path
+    from plotnine.doctools import document
+except ImportError:
+    raise ImportError("plotnine must be installed to use bumplot.geoms")
+
+
+@document
+class geom_bezier(geom_path):
+    """Draw a bezier curve between points.
+    
+    {usage}
+
+    Parameters
+    ----------
+    {common_parameters}
+
+    Examples
+    --------
+
+
+    """
+
+    DEFAULT_PARAMS = {
+        **geom_path.DEFAULT_PARAMS,
+        "curve_force": 0.5,
+    }
+
+    @staticmethod
+    def draw_group(data, panel_params, coord, ax, params: dict[str, Any]):
+        data = coord.transform(data, panel_params, munch=True)
+        data["linewidth"] = data["size"] * SIZE_FACTOR
+
+        # fixed parameter curve_force for now
+        curve_force = params["curve_force"]
+
+        # TODO: constant currently unused, but copied from plotnine
+        if "constant" in params:
+            constant: bool = params.pop("constant")
+        else:
+            constant = len(np.unique(data["group"].to_numpy())) == 1
+        
+        color = to_rgba(data["color"], data["alpha"])
+
+        indices: list[int] = []
+        paths: list[Path] = []
+
+        # TODO: this assumes not constant
+        # but plotnine has handling for constant....
+        for _, df in data.groupby("group"):
+            idx = df.index
+            indices.extend(idx[:-1].to_list())
+            vertices, codes = bezier_curve(data["x"].to_numpy(), df["y"].to_numpy(), curve_force)
+            paths.append(Path(vertices, codes))
+
+        d = {
+            "edgecolor": color if color is None else [color[i] for i in indices],
+            "linewidth": data.loc[indices, "linewidth"],
+            "linestyle": data.loc[indices, "linetype"],
+            "capstyle": params.get("lineend"),
+            "zorder": params["zorder"],
+            "rasterized": params["raster"],
+            "facecolor": "none",
+        }
+
+        coll = PathCollection(paths, **d)
+        ax.add_collection(coll)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pyfonts>=1.1.1",
     "pypalettes>=0.1.6",
     "ty>=0.0.1a20",
+    "plotnine>=0.15.0",
 ]
 quarto = [
     "jupyter>=1.1.1",


### PR DESCRIPTION
Hey @JosephBARBIERDARNAL! Don't hesitate to punt this PR, but I've been really interested in trying bumplot, while also working a bit on plotnine extensions. I decided to try out using bumplot from plotnine to see what kind of work is involved.

This is still a WIP, but I implemented a `geom_bezier()` using the bumplot `bezier_curve()` function. I think if you're up for it @has2k1 is down to help with `geom_bezier()` and a bigger `geom_bumplot()`. It could either live here or somewhere else. WDYT?!

Here it is recreating the plot from the README.

```python
import pandas as pd

from plotnine import *
from bumplot.geoms import geom_bezier

data = pd.DataFrame(
    {
        "x": [2020, 2021, 2022, 2023],
        "A": [10, 50, 20, 80],
        "B": [40, 30, 60, 10],
        "C": [90, 20, 70, 40],
    }
)
data_long = data.melt(id_vars="x", value_vars=["A", "B", "C"])

# TODO: I think a plotnine stat could do the ranking
# TODO I just use geom_bezier w/ geom_point, but geom_bumplot could do both
ranked = data_long.assign(
    rank = data_long.groupby("x")["value"].rank(ascending=False).astype(int)
)

(
    ggplot(ranked, aes("x", "rank"))
    # geom_bumplot would essentialy be bezier + point ----
    # plus the rank stat calculation
    + geom_bezier(aes(color="variable"), size=1)
    + geom_point(aes(fill="variable"), size=3, color="black")
    # match readme plot ----
    + theme_minimal()
    + scale_fill_manual(values=["#ffbe0b", "#ff006e", "#3a86ff"])
    + scale_color_manual(values=["#ffbe0b", "#ff006e", "#3a86ff"])
    + scale_y_reverse()
)
```

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/f685621b-2397-4a6f-8059-ff5600bede1b" />

It seems like this kind of bumplot stuff would be neat to show off in the [2025 Plotnine Plotting Contest](https://github.com/has2k1/plotnine/discussions/categories/2025-plotnine-contest?discussions_q=is%3Aopen+category%3A%222025+Plotnine+Contest%22) 😁 