### PR TITLE
FEAT: Customize individual Bumps

### DIFF
--- a/bumplot/__init__.py
+++ b/bumplot/__init__.py
@@ -1,4 +1,5 @@
-from .main import bumplot, Bump
+from .main import bumplot
+from .opts import opts, opts_from_color
 
 __version__ = "0.1.1"
-__all__ = ["bumplot", "Bump"]
+__all__ = ["bumplot", "opts", "opts_from_color"]

--- a/bumplot/__init__.py
+++ b/bumplot/__init__.py
@@ -1,4 +1,4 @@
-from .main import bumplot
+from .main import bumplot, Bump
 
 __version__ = "0.1.1"
-__all__ = ["bumplot"]
+__all__ = ["bumplot", "Bump"]

--- a/bumplot/_utils.py
+++ b/bumplot/_utils.py
@@ -1,15 +1,5 @@
-import matplotlib.pyplot as plt
-
 import narwhals as nw
 from narwhals.typing import IntoDataFrame
-
-
-def _get_first_n_colors(n=int) -> list[str]:
-    """
-    Get the first n colors from matplotlib rcParams.
-    """
-    colors: list[str] = plt.rcParams["axes.prop_cycle"].by_key()["color"][:n]
-    return colors
 
 
 def _ranked_df(df: IntoDataFrame, x: str, y_columns: list[str]):

--- a/bumplot/opts.py
+++ b/bumplot/opts.py
@@ -12,7 +12,7 @@ class BumpOpts(TypedDict, total=False):
     `opts()` to ensure only supported options are provided.
 
     The options are later translated into Matplotlib-specific keyword arguments
-    via `get_plot_kwargs()` and `get_scatter_kwargs()`.
+    via `_get_plot_kwargs()` and `_get_scatter_kwargs()`.
 
     Notes
     -----
@@ -129,7 +129,7 @@ def opts_from_color(color, /, **kwargs: Any) -> BumpOpts:
     return opts(**new_kwargs)
 
 
-def get_plot_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
+def _get_plot_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
     """
     Extract Matplotlib `plot` keyword arguments from a `BumpOpts` mapping.
 
@@ -160,7 +160,7 @@ def get_plot_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
     return plot_kwargs
 
 
-def get_scatter_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
+def _get_scatter_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
     """
     Extract Matplotlib `scatter` keyword arguments from a `BumpOpts` mapping.
 

--- a/bumplot/opts.py
+++ b/bumplot/opts.py
@@ -1,0 +1,74 @@
+from typing import Any, TypedDict
+
+
+class BumpOpts(TypedDict, total=False):
+    line_alpha: float
+    line_color: str
+    line_style: str
+    line_width: float
+
+    marker: str
+    marker_size: float
+    marker_alpha: float
+    marker_facecolor: str
+    marker_edgecolor: str
+    marker_edgewidth: float
+
+    clip_on: bool
+    zorder: int
+
+
+PLOT_MAPPINGS: dict[str, str] = {
+    "line_alpha": "alpha",
+    "line_color": "edgecolor",
+    "line_style": "linestyle",
+    "line_width": "linewidth",
+    "clip_on": "clip_on",
+    "zorder": "zorder",
+}
+
+SCATTER_MAPPINGS: dict[str, str] = {
+    "marker": "marker",
+    "marker_alpha": "alpha",
+    "marker_edgecolor": "edgecolor",
+    "marker_edgewidth": "linewidth",
+    "marker_facecolor": "facecolor",
+    "marker_size": "s",
+    "clip_on": "clip_on",
+    "zorder": "zorder",
+}
+
+
+def opts(**kwargs: Any) -> BumpOpts:
+    unsupported_keys = kwargs.keys() - BumpOpts.__annotations__
+    if unsupported_keys:
+        msg = f"BumpOpts got unexpected keyword argument(s) {unsupported_keys}"
+        raise TypeError(msg)
+
+    return BumpOpts(**kwargs)
+
+
+def opts_from_color(color, **kwargs: Any) -> BumpOpts:
+    overrides = ["line_color", "marker_facecolor", "marker_edgecolor"]
+    new_kwargs = {**{k: color for k in overrides}, **kwargs}
+    return opts(**new_kwargs)
+
+
+def get_plot_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
+    plot_kwargs = {}
+    for bump_arg, mpl_arg in PLOT_MAPPINGS.items():
+        try:
+            plot_kwargs[mpl_arg] = kwargs[bump_arg]  # type: ignore[invalid-key]
+        except KeyError:
+            pass
+    return plot_kwargs
+
+
+def get_scatter_kwargs(kwargs: BumpOpts, /) -> dict[str, Any]:
+    scatter_kwargs = {}
+    for bump_arg, mpl_arg in SCATTER_MAPPINGS.items():
+        try:
+            scatter_kwargs[mpl_arg] = kwargs[bump_arg]  # type: ignore[invalid-key]
+        except KeyError:
+            pass
+    return scatter_kwargs

--- a/bumplot/opts.py
+++ b/bumplot/opts.py
@@ -64,12 +64,12 @@ def opts(**kwargs: Any) -> BumpOpts:
     Construct a validated `BumpOpts` mapping from keyword arguments.
 
     This function enforces that all provided keyword arguments correspond to
-    supported ``BumpOpts`` fields. Any unexpected keys result in a ``TypeError``.
+    supported `BumpOpts` fields. Any unexpected keys result in a `TypeError`.
 
     Parameters
     ----------
     **kwargs: Unpack[BumpOpts]
-        Keyword arguments corresponding to fields defined on ``BumpOpts``.
+        Keyword arguments corresponding to fields defined on `BumpOpts`.
 
     Returns
     -------

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -15,71 +15,53 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from pyfonts import set_default_font, load_google_font
 
-from bumplot import bumplot
+from bumplot import bumplot, opts_from_color
 
 url = "https://raw.githubusercontent.com/y-sunflower/bumplot/main/docs/data/water-africa.csv"
 df = pd.read_csv(url)
 
-def ordinal(n: int) -> str:
-    if n == 1:
-        return "1st"
-    elif n == 2:
-        return "2nd"
-    elif n == 3:
-        return "3rd"
-    else:
-        return f"{n}th"
-
-
-highlight_colors = {
-    "Zambia": "#2a9d8f",
-    "Tanzania": "#bb3e03",
-}
-
-last_decade = df.index.max()
-countries = df.loc[last_decade].sort_values(ascending=False).index.to_list()[1:]
-colors = [highlight_colors.get(col, "lightgrey") for col in countries]
-
 font = load_google_font("Poppins")
 set_default_font(font)
 
+highlight = {
+    "Zambia": opts_from_color("#2a9d8f", zorder=2, line_width=3, marker_size=100),
+    "Tanzania": opts_from_color("#bb3e03", zorder=2, line_width=3, marker_size=100),
+}
+countries = [name for name in df.columns if not (name.startswith("decade"))]
 
 fig, ax = plt.subplots(figsize=(12, 5))
-bumplot(
+_, bump_artists = bumplot(
     x="decade",
-    y_columns=countries,
+    y_columns=[(name, highlight.get(name, {})) for name in countries],
     data=df,
     curve_force=0.7,
-    colors=colors,
-    scatter_kwargs={"s": 150, "clip_on": False},
-    plot_kwargs={"lw": 4},
+    ordinal_labels=True,
+    colors=["lightgray"]
 )
 ax.spines[["top", "right", "left", "bottom"]].set_visible(False)
-ax.set_xlim(1969, 2020)
+ax.margins(x=0.01)
 ax.tick_params(size=0)
 ax.tick_params(axis="x", labelsize=14, pad=10)
 ax.set_xticks(ax.get_xticks(), labels=[round(tick) for tick in ax.get_xticks()])
-ax.set_yticks(
-    [i for i in range(1, len(countries) + 1)],
-    [ordinal(i) for i in range(1, len(countries) + 1)],
-)
 
 font_bold = load_google_font("Poppins", weight="bold")
-for i, country in enumerate(countries):
+for name, (_, scatter) in bump_artists.items():
+    _, last_y = scatter.get_offsets()[-1]
     ax.text(
-        x=2021,
-        y=i + 1,
-        s=country,
+        x=1,
+        y=last_y,
+        s=name,
         size=11,
-        color=colors[i],
+        color=scatter.get_facecolor(),
         va="center",
         ha="left",
         font=font_bold,
+        transform=ax.get_yaxis_transform(),
     )
 
 fig.text(
     x=0.5,
-    y=1.02,
+    y=0.98,
     s="# of water sources installations in africa".upper(),
     size=18,
     ha="center",
@@ -88,7 +70,7 @@ fig.text(
 )
 fig.text(
     x=0.5,
-    y=0.95,
+    y=0.91,
     s="Ranking of each country based on the total number of water source installations for each decade",
     size=10,
     ha="center",
@@ -105,4 +87,6 @@ fig.text(
     font=load_google_font("Poppins", italic=True),
     size=10,
 )
+
+plt.show()
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -115,37 +115,78 @@ bumplot(
 ax.legend()
 ```
 
-### Heavily styled bump chart
+### Flexible Styling
 
 ```python
 # mkdocs: render
 import matplotlib.pyplot as plt
 import pandas as pd
-from bumplot import bumplot
 
-df = pd.DataFrame(
+from bumplot import bumplot, opts, opts_from_color
+
+data = pd.DataFrame(
     {
-        "Stage": ["Q1", "Q2", "Q3", "Q4"],
-        "Alpha": [4, 3, 2, 1],
-        "Beta": [1, 2, 4, 3],
-        "Gamma": [2, 1, 3, 4],
+        "x": [2020, 2021, 2022, 2023],
+        "A": [10, 50, 20, 80],
+        "B": [40, 30, 60, 10],
+        "C": [90, 20, 70, 40],
     }
 )
 
-fig, ax = plt.subplots(figsize=(10, 5))
+fig, axes = plt.subplots(ncols=2, nrows=2, figsize=(12, 6), layout="constrained")
+
+axes[0, 0].set_title("Basic, no additional options")
+bumplot(x="x", y_columns=["A", "B", "C"], data=data, curve_force=0.5, ax=axes[0, 0])
+
+# plot_kwargs & scatter_kwargs to set the default styles for ALL bumps
+axes[0, 1].set_title(
+    "Plot-wide customizations passed via\ncolors=…, plot_kwargs=…, scatter_kwargs=…"
+)
 bumplot(
-    x="Stage",
-    y_columns=["Alpha", "Beta", "Gamma"],
-    data=df,
-    curve_force=0.3,
-    colors=["#e63946", "#626262ff", "#457b9d"],
-    plot_kwargs={"lw": 6, "alpha": 0.7},
-    scatter_kwargs={"s": 300, "ec": "black", "lw": 2},
-    ax=ax,
+    x="x",
+    y_columns=["A", "B", "C"],
+    data=data,
+    curve_force=0.5,
+    ax=axes[0, 1],
+    colors=["#ffbe0b", "#ff006e", "#3a86ff"],
+    plot_kwargs={"lw": 4},
+    scatter_kwargs={"s": 150, "ec": "black", "lw": 2, "marker": "d"},
 )
 
-ax.set_facecolor("#f8f9fa")
-ax.legend(frameon=False, ncol=1, bbox_to_anchor=(0, 0.5))
-ax.grid(alpha=0.3, ls="--")
-ax.spines[["top", "right", "left", "bottom"]].set_visible(False)
+# Customize individual Bumps via the opts(…) helper
+# See: `bumplot.opts.BumpOpts` for all keyword arguments one can pass
+axes[1, 0].set_title("Color & Style individual lines via opts")
+bumplot(
+    x="x",
+    y_columns=[
+        ("A", opts(line_color="#ffbe0b", marker="d", marker_size=140)),
+        ("B", opts(line_color="#ff006e", line_style="--")),
+        ("C", opts_from_color("#3a86ff", line_width=5, marker_edgecolor="black")),
+    ],
+    data=data,
+    curve_force=0.5,
+    ax=axes[1, 0],
+)
+
+# Mix individual Bump options with `plot_kwargs` and `scatter_kwargs`
+axes[1, 1].set_title("Mix options to create custom charts!")
+bumplot(
+    x="x",
+    y_columns=[
+        "A",
+        ("B", opts_from_color("#ff006e", zorder=2, line_width=4, marker_size=80)),
+        "C",
+    ],
+    data=data,
+    curve_force=0.5,
+    ax=axes[1, 1],
+    plot_kwargs={"lw": 1, "ec": "gray"},
+    scatter_kwargs={"fc": "gray", "ec": "gray", "s": 20},
+)
+
+for ax in axes.flat:
+    ax.margins(x=0.05)
+    ax.spines[["top", "right"]].set_visible(False)
+
+plt.show()
 ```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import pytest
 from typing import Any
 
 import bumplot
-from bumplot.opts import get_plot_kwargs, get_scatter_kwargs
+from bumplot.opts import BumpOpts, _get_plot_kwargs, _get_scatter_kwargs
 
 
 def verify_plot_kwargs(artist: PathPatch, expected_kwargs: dict[str, Any]):
@@ -123,7 +123,9 @@ def test_bumplot(x, backend, curve_force):
     ],
     ids=["y2-default", "y2-overrides"],
 )
-def test_bumplot_options(plot_kwargs, scatter_kwargs, y2_opts):
+def test_bumplot_options(
+    plot_kwargs: dict[str, Any], scatter_kwargs: dict[str, Any], y2_opts: BumpOpts
+):
     data = {
         "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         "y1": [7, 2, 2, 5, 5, 6, 7, 2, 9, 1],
@@ -144,14 +146,16 @@ def test_bumplot_options(plot_kwargs, scatter_kwargs, y2_opts):
     )
     plt.close("all")
 
-    bump_opts = dict((y, {}) if isinstance(y, str) else y for y in y_columns)
+    bump_opts: dict[str, BumpOpts] = dict(
+        (y, bumplot.opts()) if isinstance(y, str) else y for y in y_columns
+    )
     for name, (path_patch, path_collection) in bump_artists.items():
         local_kwargs = bump_opts[name]
         if name == "y1":
             assert local_kwargs == {}
-        verify_plot_kwargs(path_patch, plot_kwargs | get_plot_kwargs(local_kwargs))
+        verify_plot_kwargs(path_patch, plot_kwargs | _get_plot_kwargs(local_kwargs))
         verify_scatter_kwargs(
-            path_collection, scatter_kwargs | get_scatter_kwargs(local_kwargs)
+            path_collection, scatter_kwargs | _get_scatter_kwargs(local_kwargs)
         )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,8 +25,7 @@ def test_version():
 )
 @pytest.mark.parametrize("backend", [pd, pl])
 @pytest.mark.parametrize("curve_force", [0, 0.5, 1, 5])
-@pytest.mark.parametrize("colors", [None, ["#ffbe0b", "#ff006e", "#3a86ff"]])
-def test_bumplot(x, backend, curve_force, colors):
+def test_bumplot(x, backend, curve_force):
     data = {
         "x": x,
         "y1": [7, 2, 2, 5, 5, 6, 7, 2, 9, 1],
@@ -36,13 +35,12 @@ def test_bumplot(x, backend, curve_force, colors):
     df = backend.DataFrame(data)
 
     _, ax = plt.subplots(figsize=(6, 4))
-    ax2 = bumplot.bumplot(
+    ax2, bump_artists = bumplot.bumplot(
         x="x",
         y_columns=["y1", "y2", "y3"],
         data=df,
         ax=ax,
         curve_force=curve_force,
-        colors=colors,
     )
 
     assert isinstance(ax2, Axes)
@@ -61,31 +59,6 @@ def test_bumplot(x, backend, curve_force, colors):
     plt.close("all")
 
 
-def test_bumplot_error():
-    data = {
-        "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "y1": [7, 2, 2, 5, 5, 6, 7, 2, 9, 1],
-        "y2": [3, 2, 1, 10, 4, 8, 7, 2, 4, 2],
-        "y3": [5, 4, 10, 1, 3, 6, 5, 2, 3, 7],
-    }
-    df = pd.DataFrame(data)
-    _, ax = plt.subplots(figsize=(6, 4))
-
-    with pytest.raises(
-        ValueError,
-        match="Not enough colors: expected at least 3, but got 2",
-    ):
-        bumplot.bumplot(
-            x="x",
-            y_columns=["y1", "y2", "y3"],
-            data=df,
-            ax=ax,
-            colors=["black", "black"],
-        )
-
-    plt.close("all")
-
-
 @pytest.mark.parametrize("ordinal_labels", [True, False])
 def test_bumplot_ordinal_labels(ordinal_labels):
     """Test that ordinal labels work correctly"""
@@ -100,7 +73,7 @@ def test_bumplot_ordinal_labels(ordinal_labels):
     df = pd.DataFrame(data)
 
     fig, ax = plt.subplots()
-    ax = bumplot.bumplot(
+    bumplot.bumplot(
         x="x",
         y_columns=["y1", "y2", "y3", "y4", "y5"],
         data=df,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-from matplotlib.axes import Axes
+from matplotlib.colors import to_rgb
 from matplotlib.patches import PathPatch
 from matplotlib.collections import PathCollection
 
@@ -7,8 +7,35 @@ import pandas as pd
 import polars as pl
 
 import pytest
+from typing import Any
 
 import bumplot
+from bumplot.opts import get_plot_kwargs, get_scatter_kwargs
+
+
+def verify_plot_kwargs(artist: PathPatch, expected_kwargs: dict[str, Any]):
+    for k, v in expected_kwargs.items():
+        if k == "edgecolor":
+            assert artist.get_edgecolor()[:3] == to_rgb(v)
+        else:
+            assert getattr(artist, f"get_{k}")() == v
+
+
+def verify_scatter_kwargs(artist: PathCollection, expected_kwargs: dict[str, Any]):
+    assert isinstance(artist, PathCollection)
+
+    for k, v in expected_kwargs.items():
+        if k == "marker":
+            # Matplotlib ingests the marker identifier and transforms it
+            #   we would need to recover/repeat the specific transformations
+            #   or normalize back for comparison
+            continue
+        elif k == "s":
+            assert artist.get_sizes()[0] == v
+        elif k.endswith("color"):
+            assert (getattr(artist, f"get_{k}")()[0, :3] == to_rgb(v)).all()
+        else:
+            assert getattr(artist, f"get_{k}")() == v
 
 
 def test_version():
@@ -34,29 +61,98 @@ def test_bumplot(x, backend, curve_force):
     }
     df = backend.DataFrame(data)
 
-    _, ax = plt.subplots(figsize=(6, 4))
-    ax2, bump_artists = bumplot.bumplot(
+    y_columns = ["y1", "y2", "y3"]
+    _, in_ax = plt.subplots(figsize=(6, 4))
+    out_ax, bump_artists = bumplot.bumplot(
         x="x",
-        y_columns=["y1", "y2", "y3"],
+        y_columns=y_columns,
         data=df,
-        ax=ax,
+        ax=in_ax,
         curve_force=curve_force,
     )
 
-    assert isinstance(ax2, Axes)
-    assert ax == ax2
-
-    artists = ax.get_children()
-
-    pathpatches = [artist for artist in artists if isinstance(artist, PathPatch)]
-    assert len(pathpatches) == 3
-
-    pathcollections = [
-        artist for artist in artists if isinstance(artist, PathCollection)
-    ]
-    assert len(pathcollections) == 3
+    assert in_ax is out_ax
+    assert len(bump_artists) == len(y_columns)
+    assert bump_artists.keys() == set(y_columns)
 
     plt.close("all")
+
+
+@pytest.mark.parametrize(
+    "plot_kwargs",
+    [
+        {},
+        {
+            "alpha": 0.1,
+            "edgecolor": "blue",
+            "linestyle": "--",
+            "linewidth": 3,
+            "clip_on": True,
+            "zorder": 2,
+        },
+    ],
+    ids=["no-plot-kwargs", "with-plot-kwargs"],
+)
+@pytest.mark.parametrize(
+    "scatter_kwargs",
+    [
+        {},
+        {
+            "marker": "d",
+            "alpha": 0.2,
+            "edgecolor": "red",
+            "facecolor": "orange",
+            "linewidth": 0.3,
+            "s": 51,
+            "clip_on": True,
+            "zorder": 3,
+        },
+    ],
+    ids=["no-scatter-kwargs", "with-scatter-kwargs"],
+)
+@pytest.mark.parametrize(
+    "y2_opts",
+    [
+        bumplot.opts(),
+        bumplot.opts(
+            marker_facecolor="blue",
+            line_width=3,
+            line_alpha=0.1,
+            marker_alpha=0.6,
+        ),
+    ],
+    ids=["y2-default", "y2-overrides"],
+)
+def test_bumplot_options(plot_kwargs, scatter_kwargs, y2_opts):
+    data = {
+        "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "y1": [7, 2, 2, 5, 5, 6, 7, 2, 9, 1],
+        "y2": [3, 2, 1, 10, 4, 8, 7, 2, 4, 2],
+        "y3": [5, 4, 10, 1, 3, 6, 5, 2, 3, 7],
+    }
+    df = pd.DataFrame(data)
+
+    y_columns = ["y1", ("y2", y2_opts)]
+    _, ax = plt.subplots(figsize=(6, 4))
+    _, bump_artists = bumplot.bumplot(
+        x="x",
+        y_columns=y_columns,
+        data=df,
+        ax=ax,
+        scatter_kwargs=scatter_kwargs,
+        plot_kwargs=plot_kwargs,
+    )
+    plt.close("all")
+
+    bump_opts = dict((y, {}) if isinstance(y, str) else y for y in y_columns)
+    for name, (path_patch, path_collection) in bump_artists.items():
+        local_kwargs = bump_opts[name]
+        if name == "y1":
+            assert local_kwargs == {}
+        verify_plot_kwargs(path_patch, plot_kwargs | get_plot_kwargs(local_kwargs))
+        verify_scatter_kwargs(
+            path_collection, scatter_kwargs | get_scatter_kwargs(local_kwargs)
+        )
 
 
 @pytest.mark.parametrize("ordinal_labels", [True, False])
@@ -83,9 +179,6 @@ def test_bumplot_ordinal_labels(ordinal_labels):
     )
 
     y_labels = [label.get_text() for label in ax.get_yticklabels()]
-
-    print(f"Y labels: {y_labels}")
-    print(f"Y ticks: {ax.get_yticks()}")
 
     if ordinal_labels:
         assert y_labels == ["5th", "4th", "3rd", "2nd", "1st"], (

--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -1,0 +1,90 @@
+import pytest
+
+from bumplot import opts, opts_from_color
+from bumplot.opts import get_plot_kwargs, get_scatter_kwargs
+
+
+def test_opts_accepts_all_valid_keys():
+    kwargs = dict(
+        line_alpha=0.5,
+        line_color="red",
+        line_style="--",
+        line_width=2.0,
+        marker="o",
+        marker_size=10,
+        marker_alpha=0.8,
+        marker_facecolor="blue",
+        marker_edgecolor="black",
+        marker_edgewidth=1.5,
+        clip_on=True,
+        zorder=3,
+    )
+
+    assert opts(**kwargs) == kwargs
+
+
+def test_opts_raise_unknown_key():
+    with pytest.raises(TypeError, match="unexpected keyword argument") as exc:
+        opts(foo=1)
+    msg = str(exc.value)
+    assert "'foo'" in msg
+
+    with pytest.raises(TypeError, match="unexpected keyword argument") as exc:
+        opts(foo=1, bar=2)
+
+    msg = str(exc.value)
+    assert "'bar'" in msg
+    assert "'foo'" in msg
+
+
+def test_opts_accepts_empty():
+    assert opts() == {}
+
+
+def test_opts_from_color_sets_all_color_fields():
+    o = opts_from_color("red")
+
+    assert o["line_color"] == "red"
+    assert o["marker_facecolor"] == "red"
+    assert o["marker_edgecolor"] == "red"
+
+
+def test_opts_from_color_overriden():
+    o = opts_from_color(
+        "red",
+        marker_facecolor="blue",
+    )
+
+    assert o["marker_facecolor"] == "blue"
+    assert o["marker_edgecolor"] == "red"
+    assert o["line_color"] == "red"
+
+
+def test_get_scatter_kwargs_basic_mapping():
+    bump = opts(
+        marker="o",
+        marker_size=12,
+        marker_alpha=0.6,
+        marker_edgewidth=2.0,
+        clip_on=False,
+    )
+
+    out = get_scatter_kwargs(bump)
+
+    assert out == {
+        "marker": "o",
+        "s": 12,
+        "alpha": 0.6,
+        "linewidth": 2.0,
+        "clip_on": False,
+    }
+
+
+def test_getters_do_not_mutate_input():
+    bump = opts(line_alpha=0.5)
+    original = dict(bump)
+
+    get_plot_kwargs(bump)
+    get_scatter_kwargs(bump)
+
+    assert bump == original

--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -1,7 +1,7 @@
 import pytest
 
 from bumplot import opts, opts_from_color
-from bumplot.opts import get_plot_kwargs, get_scatter_kwargs
+from bumplot.opts import _get_plot_kwargs, _get_scatter_kwargs
 
 
 def test_opts_accepts_all_valid_keys():
@@ -44,9 +44,9 @@ def test_opts_accepts_empty():
 def test_opts_from_color_sets_all_color_fields():
     o = opts_from_color("red")
 
-    assert o["line_color"] == "red"
-    assert o["marker_facecolor"] == "red"
-    assert o["marker_edgecolor"] == "red"
+    assert o["line_color"] == "red"  # type: ignore[reportTypedDictNotRequiredAccess]
+    assert o["marker_facecolor"] == "red"  # type: ignore[reportTypedDictNotRequiredAccess]
+    assert o["marker_edgecolor"] == "red"  # type: ignore[reportTypedDictNotRequiredAccess]
 
 
 def test_opts_from_color_overriden():
@@ -55,9 +55,27 @@ def test_opts_from_color_overriden():
         marker_facecolor="blue",
     )
 
-    assert o["marker_facecolor"] == "blue"
-    assert o["marker_edgecolor"] == "red"
-    assert o["line_color"] == "red"
+    assert o["marker_facecolor"] == "blue"  # type: ignore[reportTypedDictNotRequiredAccess]
+    assert o["marker_edgecolor"] == "red"  # type: ignore[reportTypedDictNotRequiredAccess]
+    assert o["line_color"] == "red"  # type: ignore[reportTypedDictNotRequiredAccess]
+
+
+def test_get_plot_kwargs_basic_mapping():
+    bump = opts(
+        line_width=4,
+        line_alpha=0.6,
+        clip_on=False,
+        zorder=3,
+    )
+
+    out = _get_plot_kwargs(bump)
+
+    assert out == {
+        "alpha": 0.6,
+        "linewidth": 4,
+        "clip_on": False,
+        "zorder": 3,
+    }
 
 
 def test_get_scatter_kwargs_basic_mapping():
@@ -69,7 +87,7 @@ def test_get_scatter_kwargs_basic_mapping():
         clip_on=False,
     )
 
-    out = get_scatter_kwargs(bump)
+    out = _get_scatter_kwargs(bump)
 
     assert out == {
         "marker": "o",
@@ -84,7 +102,7 @@ def test_getters_do_not_mutate_input():
     bump = opts(line_alpha=0.5)
     original = dict(bump)
 
-    get_plot_kwargs(bump)
-    get_scatter_kwargs(bump)
+    _get_plot_kwargs(bump)
+    _get_scatter_kwargs(bump)
 
     assert bump == original


### PR DESCRIPTION
In response to #7 and #6

This feature allows one to have a fine control over individual plotting arguments for each individual line/scatter (PathPatch/PathCollection).

## Code Changes

**Behavior Changes**
The default `bumplot` is now less colorful (no color cycler), encouraging users to opt-in to telling some data story.

**Additions**
- `Bump` dataclass provides options for individual columns
- `bumplot` now returns the artists created for the plot itself. This serves as both a convenience and an escape hatch (instead of passing options into the `bumplot` function, let the users set the options directly on the returned artists.

**Removals**
- `bumplot(..., colors=...)`  colors was removed in favor of passing the color into the Bump object (tying the color and other options directly to the column)
- `_get_first_n_colors` was only used when `colors=None`. We now simply use the colors that are explicitly passed in from the `Bump` objects. This function also encouraged visually distracting (but colorful!) charts.
- `bumplot(..., plot_kwargs=..., scatter_kwargs=...)` are no longer needed since `Bump` covers the most common options. If additional options need to be passed, users should set them on the returned Artists.

**Further Consideration**
I'm not sure I'm 100% sold on the removal of the color cycling as it can be useful during quick data explorations. If we want to preserve this behavior (I don't think it should be the default), we can likely set up a way to generate Bump instances that follow the default `axes.prop_cycle`. This could be its own `BumpCycled` class or a class method that returns a factory function on the current `Bump` type.

## Examples

```python
import matplotlib.pyplot as plt
import pandas as pd

from bumplot import bumplot, Bump

data = pd.DataFrame(
    {
        "x": [2020, 2021, 2022, 2023],
        "A": [10, 50, 20, 80],
        "B": [40, 30, 60, 10],
        "C": [90, 20, 70, 40],
    }
)

fig, ax = plt.subplots(figsize=(8, 4))
_, artists = bumplot(
    x="x",
    y_columns=[
        "A",
        Bump("B", marker_facecolor="red", marker_edgecolor="blue", line_width=5),
        Bump("C", line_color="orange", marker="d", marker_size=140)
    ],
    data=data,
    curve_force=0.5,
)
ax.legend()
ax.spines[["top", "right", "left", "bottom"]].set_visible(False)

plt.show()
```
<img width="697" height="368" alt="image" src="https://github.com/user-attachments/assets/b5f6d1d7-bda0-4fef-b82a-93bd14bf6c3e" />

---

The below is adapted from: https://y-sunflower.github.io/bumplot/advanced-usage/

```python
import pandas as pd
import matplotlib.pyplot as plt
from pyfonts import set_default_font, load_google_font

from bumplot import bumplot, Bump

url = "https://raw.githubusercontent.com/y-sunflower/bumplot/main/docs/data/water-africa.csv"
df = pd.read_csv(url)

font = load_google_font("Poppins")
set_default_font(font)

highlight = [
    Bump("Zambia", line_color="#2a9d8f", marker_facecolor="#2a9d8f"),
    Bump("Tanzania", line_color="#bb3e03", marker_facecolor="#bb3e03"),
]
highlight_names = {b.name for b in highlight}
non_highlight = [
    Bump(name) for name in df.columns
    if not (name.startswith("decade") or name in highlight_names)
]

fig, ax = plt.subplots(figsize=(12, 5))
_, bump_artists = bumplot(
    x="decade",
    y_columns=[*non_highlight, *highlight],
    data=df,
    curve_force=0.7,
    ordinal_labels=True,
)
ax.spines[["top", "right", "left", "bottom"]].set_visible(False)
ax.margins(x=0.01)
ax.tick_params(size=0)
ax.tick_params(axis="x", labelsize=14, pad=10)
ax.set_xticks(ax.get_xticks(), labels=[round(tick) for tick in ax.get_xticks()])

font_bold = load_google_font("Poppins", weight="bold")
for bump, (line, scatter) in bump_artists.items():
    _, last_y = scatter.get_offsets()[-1]
    ax.text(
        x=1,
        y=last_y,
        s=bump.name,
        size=11,
        color=bump.line_color,
        va="center",
        ha="left",
        font=font_bold,
        transform=ax.get_yaxis_transform(),
    )

fig.text(
    x=0.5,
    y=0.98,
    s="# of water sources installations in africa".upper(),
    size=18,
    ha="center",
    va="top",
    font=font_bold,
)
fig.text(
    x=0.5,
    y=0.91,
    s="Ranking of each country based on the total number of water source installations for each decade",
    size=10,
    ha="center",
    va="top",
    color="grey",
    font=load_google_font("Poppins", italic=True),
)
fig.text(
    x=0.12,
    y=0,
    s="Made with bumplot\nGraphic: Joseph Barbier",
    va="top",
    color="grey",
    font=load_google_font("Poppins", italic=True),
    size=10,
)

plt.show()
```

<img width="1064" height="480" alt="image" src="https://github.com/user-attachments/assets/44e9db7e-4686-4e5a-bb20-0424480d10f7" />
